### PR TITLE
Add AGENTS.md for development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+TotalCalendarJS is a zero-dependency, static HTML/JavaScript web application for managing timed training/exercise routines with text-to-speech voice guidance. The UI is entirely in Russian.
+
+### Running the application
+
+No build step required. Serve the workspace root via any static HTTP server:
+
+```bash
+python3 -m http.server 8080 --directory /workspace
+```
+
+Then open `http://localhost:8080/index.html` in a browser.
+
+**Important**: `index_ref.html` uses `fetch("./index.html")` internally, so files must be served over HTTP (not `file://`).
+
+### Key files
+
+- `index.html` — Main application (current version)
+- `index1.html` — Slightly older version
+- `index_old.html` — Oldest version
+- `index_ref.html` — Wrapper that loads and normalizes `index.html` via fetch
+- `StableVoice.html` — Standalone text-to-speech utility page
+
+### Testing and linting
+
+There are no automated tests, linter configurations, or CI/CD pipelines in this repository. The application is tested manually by interacting with it in a browser.
+
+### Browser requirements
+
+The application requires a modern browser with `SpeechSynthesis` API support (Chrome, Edge, Firefox, Safari). It also uses the `WakeLock` API and `AudioContext`.
+
+### Notes
+
+- The codebase uses Russian-language variable names and UI labels.
+- All code is inline within monolithic HTML files (~4000+ lines each).
+- No package manager, no node_modules, no external dependencies.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

## What this does

This PR adds documentation for future cloud agents to quickly understand and work with this codebase:

- **Overview**: Describes TotalCalendarJS as a zero-dependency static HTML/JS app
- **Running instructions**: How to serve the app locally (`python3 -m http.server 8080`)
- **Key files**: Maps the main HTML files and their purposes
- **Testing notes**: Documents that there are no automated tests (manual browser testing only)
- **Browser requirements**: Notes the SpeechSynthesis, WakeLock, and AudioContext API dependencies

## Demo

The application running successfully in the development environment:

[demo_training_calendar_app.mp4](https://cursor.com/agents/bc-974d282f-a60e-4842-b504-75a0dd975b13/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_training_calendar_app.mp4)

Main UI loaded:
[Main application UI](https://cursor.com/agents/bc-974d282f-a60e-4842-b504-75a0dd975b13/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_main_ui.webp)

Training dropdown with options:
[Training selection dropdown](https://cursor.com/agents/bc-974d282f-a60e-4842-b504-75a0dd975b13/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_dropdown_menu.webp)

Active training session with timer and navigation:
[Training session active](https://cursor.com/agents/bc-974d282f-a60e-4842-b504-75a0dd975b13/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_training_active.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-974d282f-a60e-4842-b504-75a0dd975b13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-974d282f-a60e-4842-b504-75a0dd975b13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

