### PR TITLE
Add Android WebView app shell

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,0 +1,5 @@
+.gradle/
+local.properties
+build/
+*/build/
+captures/

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,26 @@
+# Total Calendar Android
+
+This directory contains a native Android wrapper for the existing Total Calendar
+HTML app.
+
+## What the app does
+
+- Loads `index.html` from Android assets in a `WebView`.
+- Copies the repository's top-level `*.html` files into the APK at build time.
+- Exposes an `AndroidTraining` JavaScript bridge so the web app can:
+  - keep the Android screen on while a training run is active;
+  - stop native speech when training is stopped or muted;
+  - use Android `TextToSpeech` instead of browser speech synthesis inside the
+    Android app.
+
+## Build
+
+Open this `android/` directory in Android Studio, or build from a machine with
+Gradle and the Android SDK installed:
+
+```sh
+gradle :app:assembleDebug
+```
+
+The Android Gradle Plugin version in this project requires Gradle 9.4.1 or
+newer and Android SDK 36.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,35 @@
+plugins {
+    id 'com.android.application'
+}
+
+def generatedWebAssetsDir = layout.buildDirectory.dir('generated/web-assets')
+
+android {
+    namespace 'com.totalcalendarjs.app'
+    compileSdk 36
+
+    defaultConfig {
+        applicationId 'com.totalcalendarjs.app'
+        minSdk 23
+        targetSdk 36
+        versionCode 1
+        versionName '1.0'
+    }
+
+    sourceSets {
+        main {
+            assets.srcDir(generatedWebAssetsDir)
+        }
+    }
+}
+
+tasks.register('syncWebAssets', Copy) {
+    from(rootProject.projectDir.parentFile) {
+        include '*.html'
+    }
+    into(generatedWebAssetsDir)
+}
+
+tasks.named('preBuild').configure {
+    dependsOn('syncWebAssets')
+}

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -16,6 +16,11 @@ android {
         versionName '1.0'
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
     sourceSets {
         main {
             assets.srcDir(generatedWebAssetsDir)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowBackup="true"
+        android:label="Total Calendar"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme">
+        <activity
+            android:name=".MainActivity"
+            android:configChanges="keyboardHidden|orientation|screenSize"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:allowBackup="true"
         android:label="Total Calendar"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"

--- a/android/app/src/main/java/com/totalcalendarjs/app/MainActivity.java
+++ b/android/app/src/main/java/com/totalcalendarjs/app/MainActivity.java
@@ -1,0 +1,260 @@
+package com.totalcalendarjs.app;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.ActivityNotFoundException;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.speech.tts.TextToSpeech;
+import android.view.WindowManager;
+import android.webkit.JavascriptInterface;
+import android.webkit.JsResult;
+import android.webkit.ValueCallback;
+import android.webkit.WebChromeClient;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import java.util.ArrayDeque;
+import java.util.Locale;
+
+public final class MainActivity extends Activity implements TextToSpeech.OnInitListener {
+    private static final int FILE_CHOOSER_REQUEST_CODE = 42;
+    private static final int MAX_PENDING_SPEECH_ITEMS = 20;
+
+    private WebView webView;
+    private ValueCallback<Uri[]> filePathCallback;
+    private TextToSpeech textToSpeech;
+    private boolean textToSpeechReady;
+    private final ArrayDeque<SpeechRequest> pendingSpeech = new ArrayDeque<>();
+
+    @SuppressLint({"SetJavaScriptEnabled", "AddJavascriptInterface"})
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        textToSpeech = new TextToSpeech(this, this);
+        webView = new WebView(this);
+        setContentView(webView);
+
+        configureWebView();
+        webView.addJavascriptInterface(new TrainingBridge(), "AndroidTraining");
+
+        if (savedInstanceState == null) {
+            webView.loadUrl("file:///android_asset/index.html");
+        } else {
+            webView.restoreState(savedInstanceState);
+        }
+    }
+
+    private void configureWebView() {
+        WebSettings settings = webView.getSettings();
+        settings.setJavaScriptEnabled(true);
+        settings.setDomStorageEnabled(true);
+        settings.setDatabaseEnabled(true);
+        settings.setMediaPlaybackRequiresUserGesture(false);
+        settings.setAllowFileAccess(true);
+        settings.setAllowContentAccess(true);
+        settings.setAllowFileAccessFromFileURLs(true);
+        settings.setAllowUniversalAccessFromFileURLs(true);
+        settings.setLoadWithOverviewMode(true);
+        settings.setUseWideViewPort(true);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            settings.setSafeBrowsingEnabled(true);
+        }
+
+        webView.setWebViewClient(new WebViewClient() {
+            @Override
+            public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+                Uri uri = request.getUrl();
+                if ("http".equals(uri.getScheme()) || "https".equals(uri.getScheme()) || "file".equals(uri.getScheme())) {
+                    return false;
+                }
+
+                openExternalUri(uri);
+                return true;
+            }
+        });
+
+        webView.setWebChromeClient(new WebChromeClient() {
+            @Override
+            public boolean onShowFileChooser(
+                    WebView view,
+                    ValueCallback<Uri[]> callback,
+                    FileChooserParams fileChooserParams
+            ) {
+                if (filePathCallback != null) {
+                    filePathCallback.onReceiveValue(null);
+                }
+
+                filePathCallback = callback;
+                try {
+                    startActivityForResult(fileChooserParams.createIntent(), FILE_CHOOSER_REQUEST_CODE);
+                    return true;
+                } catch (ActivityNotFoundException exception) {
+                    filePathCallback = null;
+                    return false;
+                }
+            }
+
+            @Override
+            public boolean onJsAlert(WebView view, String url, String message, JsResult result) {
+                new AlertDialog.Builder(MainActivity.this)
+                        .setMessage(message)
+                        .setPositiveButton(android.R.string.ok, (dialog, which) -> result.confirm())
+                        .setOnCancelListener(dialog -> result.cancel())
+                        .show();
+                return true;
+            }
+        });
+    }
+
+    private void openExternalUri(Uri uri) {
+        try {
+            startActivity(new Intent(Intent.ACTION_VIEW, uri));
+        } catch (ActivityNotFoundException ignored) {
+            // If Android has no handler for the scheme, keep the user inside the app.
+        }
+    }
+
+    @Override
+    public void onInit(int status) {
+        if (status != TextToSpeech.SUCCESS || textToSpeech == null) {
+            pendingSpeech.clear();
+            return;
+        }
+
+        int languageStatus = textToSpeech.setLanguage(new Locale("ru"));
+        if (languageStatus == TextToSpeech.LANG_MISSING_DATA || languageStatus == TextToSpeech.LANG_NOT_SUPPORTED) {
+            textToSpeech.setLanguage(Locale.getDefault());
+        }
+
+        textToSpeechReady = true;
+        while (!pendingSpeech.isEmpty()) {
+            SpeechRequest request = pendingSpeech.removeFirst();
+            speakOnUiThread(request.text, request.rate);
+        }
+    }
+
+    private void speakOnUiThread(String text, float rate) {
+        if (text == null || text.trim().isEmpty()) {
+            return;
+        }
+
+        if (!textToSpeechReady || textToSpeech == null) {
+            if (pendingSpeech.size() >= MAX_PENDING_SPEECH_ITEMS) {
+                pendingSpeech.removeFirst();
+            }
+            pendingSpeech.addLast(new SpeechRequest(text, rate));
+            return;
+        }
+
+        textToSpeech.setSpeechRate(rate);
+        textToSpeech.speak(text, TextToSpeech.QUEUE_ADD, null, "training-" + System.nanoTime());
+    }
+
+    private void stopSpeechOnUiThread() {
+        pendingSpeech.clear();
+        if (textToSpeech != null) {
+            textToSpeech.stop();
+        }
+    }
+
+    private float normalizeSpeechRate(double rate) {
+        if (Double.isNaN(rate) || Double.isInfinite(rate) || rate <= 0) {
+            return 1.0f;
+        }
+        return Math.max(0.1f, Math.min((float) rate, 3.0f));
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode != FILE_CHOOSER_REQUEST_CODE || filePathCallback == null) {
+            return;
+        }
+
+        Uri[] results = WebChromeClient.FileChooserParams.parseResult(resultCode, data);
+        filePathCallback.onReceiveValue(results);
+        filePathCallback = null;
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        webView.saveState(outState);
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (webView != null && webView.canGoBack()) {
+            webView.goBack();
+            return;
+        }
+        super.onBackPressed();
+    }
+
+    @Override
+    protected void onDestroy() {
+        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+
+        if (filePathCallback != null) {
+            filePathCallback.onReceiveValue(null);
+            filePathCallback = null;
+        }
+
+        if (webView != null) {
+            webView.removeJavascriptInterface("AndroidTraining");
+            webView.destroy();
+            webView = null;
+        }
+
+        if (textToSpeech != null) {
+            textToSpeech.stop();
+            textToSpeech.shutdown();
+            textToSpeech = null;
+        }
+
+        super.onDestroy();
+    }
+
+    public final class TrainingBridge {
+        @JavascriptInterface
+        public void startTrainingGuard() {
+            runOnUiThread(() -> getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON));
+        }
+
+        @JavascriptInterface
+        public void stopTrainingGuard() {
+            runOnUiThread(() -> {
+                getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+                stopSpeechOnUiThread();
+            });
+        }
+
+        @JavascriptInterface
+        public void stopSpeech() {
+            runOnUiThread(() -> stopSpeechOnUiThread());
+        }
+
+        @JavascriptInterface
+        public void speak(String text, double rate) {
+            runOnUiThread(() -> speakOnUiThread(text, normalizeSpeechRate(rate)));
+        }
+    }
+
+    private static final class SpeechRequest {
+        private final String text;
+        private final float rate;
+
+        private SpeechRequest(String text, float rate) {
+            this.text = text;
+            this.rate = rate;
+        }
+    }
+}

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme" parent="android:style/Theme.Material.Light.NoActionBar">
+        <item name="android:colorAccent">#2563eb</item>
+        <item name="android:fontFamily">sans</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
+    </style>
+</resources>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'com.android.application' version '9.2.0' apply false
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = 'TotalCalendarAndroid'
+include ':app'

--- a/index.html
+++ b/index.html
@@ -507,7 +507,7 @@
             <div class="option-grid">
                 <label class="option-card checkbox-line" for="idNoSound">
                     <span><strong>Без звука:</strong></span>
-                    <input id="idNoSound" type="checkbox" onclick="if (!this.checked) document.getElementById('idTextTrain').style.display='none'; else {document.getElementById('idTextTrain').style.display='block'; window.speechSynthesis.cancel()}">
+                    <input id="idNoSound" type="checkbox" onclick="if (!this.checked) document.getElementById('idTextTrain').style.display='none'; else {document.getElementById('idTextTrain').style.display='block'; stopCurrentSpeech()}">
                 </label>
                 <label class="option-card checkbox-line" for="idStopSpeakIfNext">
                     <span><strong>Прерывать текст упражнения сразу при наступлении времени следующего:</strong></span>
@@ -746,10 +746,48 @@ function resumeTrainingAudio(){
   }catch(e){}
 }
 
+function callAndroidTraining(methodName){
+  try{
+    if (window.AndroidTraining && typeof window.AndroidTraining[methodName] === "function"){
+      var args = Array.prototype.slice.call(arguments, 1)
+      window.AndroidTraining[methodName].apply(window.AndroidTraining, args)
+      return true
+    }
+  }catch(e){
+    console.log("Android training bridge error:", e)
+  }
+
+  return false
+}
+
+function stopCurrentSpeech(){
+  callAndroidTraining("stopSpeech")
+
+  try{
+    if (window.speechSynthesis)
+      window.speechSynthesis.cancel()
+  }catch(e){}
+}
+
+function speakWithAndroidTraining(str){
+  var rate = 1
+
+  try{
+    rate = Number(document.getElementById("inputRate").value) || 1
+  }catch(e){}
+
+  return callAndroidTraining("speak", String(str), rate)
+}
+
 function startTrainingAudioGuard(){
   Gl_WakeLockWanted = true
+  var androidGuardStarted = callAndroidTraining("startTrainingGuard")
   clearTimeout(Gl_AudioGuardStopTimer)
   Gl_AudioGuardStopTimer = null
+
+  if (androidGuardStarted)
+    return
+
   requestTrainingWakeLock()
   startTrainingBackgroundAudio()
 
@@ -796,6 +834,7 @@ function finishTrainingPlayback(){
 
 function stopTrainingAudioGuard(){
   Gl_WakeLockWanted = false
+  callAndroidTraining("stopTrainingGuard")
 
   clearTimeout(Gl_AudioGuardStopTimer)
   Gl_AudioGuardStopTimer = null
@@ -869,6 +908,8 @@ async function requestTrainingWakeLock(){
 
 document.addEventListener("visibilitychange", function(){
   if (document.visibilityState === "visible"){
+    if (Gl_WakeLockWanted)
+      callAndroidTraining("startTrainingGuard")
     requestTrainingWakeLock()
     resumeTrainingAudio()
   }
@@ -2598,7 +2639,7 @@ GI-11 убираем с поверхности. https://www.eledia.ru/_pu/0/6500
     ];
   var GlTest = 1;
   var GltxtSpeek  = document.getElementById("idTextsToSpeek");
-  var GlUtterance = new SpeechSynthesisUtterance("");
+  var GlUtterance = (typeof SpeechSynthesisUtterance !== "undefined") ? new SpeechSynthesisUtterance("") : null;
   var calendar = document.getElementById("actionsInCalendar");
   var currentT = document.getElementById("currentT");
   var inputMinDay = document.getElementById("inputMinDay");
@@ -3011,11 +3052,13 @@ END:VEVENT\n`
         }catch(e){}
 
         if (!docNoSound.checked){
-            var utterance0 = new SpeechSynthesisUtterance(str);
-            utterance0.rate=document.getElementById("inputRate").value;// 1.5; //скорость речи
-            if (Gl_StopSpeakIfNext) window.speechSynthesis.cancel()
+            if (Gl_StopSpeakIfNext) stopCurrentSpeech()
             resumeTrainingAudio()
-            window.speechSynthesis.speak(utterance0);
+            if (!speakWithAndroidTraining(str) && typeof SpeechSynthesisUtterance !== "undefined" && window.speechSynthesis){
+                var utterance0 = new SpeechSynthesisUtterance(str);
+                utterance0.rate=document.getElementById("inputRate").value;// 1.5; //скорость речи
+                window.speechSynthesis.speak(utterance0);
+            }
             //
         } else{
             docTextTrain.value = str
@@ -3969,7 +4012,7 @@ END:VEVENT\n`
   function navigate(i){ // для навигации по делам текущей трени
      if (Gl_decodeExternalCallValue.length=0)
          alert ("Будет произведен переход на дело '"+Gl_aRithmLisp[i]+"'")
-     window.speechSynthesis.cancel()
+     stopCurrentSpeech()
 
      for(var j=0; j<i;j++){
         try{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a native Android WebView wrapper that packages the existing HTML app
- expose an Android JavaScript bridge for training screen-on control and native TextToSpeech
- update the web app speech/guard logic to use Android-native behavior when the bridge is present, with browser behavior as fallback
- add Android build-output ignores and Java compatibility settings

## Testing
- extracted inline JavaScript from `index.html` and ran `node --check`
- `git diff --check`
- parsed Android XML files with Python `xml.etree.ElementTree`
- confirmed Android project files are present

## Not run
- Android APK build (`gradle` is not installed in this cloud image)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4ba777f-ca22-48f1-8f30-d9433d334e5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4ba777f-ca22-48f1-8f30-d9433d334e5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

